### PR TITLE
Adds drop pin to post location link

### DIFF
--- a/src/views/Post.js
+++ b/src/views/Post.js
@@ -51,7 +51,7 @@ class PostView extends Component {
           className="Post__info__location"
           href={`http://maps.apple.com/?ll=${this.props.location_lat},${
             this.props.location_lon
-          }`}
+          }&q=${this.props.location_name}`}
         >
           {this.props.location_name}
         </a>


### PR DESCRIPTION
This adds the `q` parameter to the Apple Maps link, providing support for a drop pin. I've used the location name as the title for the pin.